### PR TITLE
[BUGFIX] Rename path of js file to load

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <requirejs>
             {
                 "paths": {
-                    "angular-ui-select": "angular-ui-select"
+                    "angular-ui-select": "select"
                 },
                 "shim": {
                     "angular-ui-select": ["angular"]


### PR DESCRIPTION
The current setting tries to load an absent file.
`select.js` is the real one.
